### PR TITLE
Reset model indexes to enable schema changes

### DIFF
--- a/backend/src/db/db-reset-indexes.js
+++ b/backend/src/db/db-reset-indexes.js
@@ -7,7 +7,7 @@ import { RoadTrip } from "./models/RoadTrip.js";
 import { Spotify } from "./models/Spotify.js";
 import { User } from "./models/User.js";
 
-export default async function resetDatabase() {
+export default async function syncAllIndexes() {
     await EmergencyDetails.syncIndexes();
     await Itinerary.syncIndexes();
     await Map.syncIndexes();

--- a/backend/src/db/db-reset.js
+++ b/backend/src/db/db-reset.js
@@ -1,0 +1,20 @@
+import { EmergencyDetails } from "./models/EmergencyDetails.js";
+import { Itinerary } from "./models/Itinerary.js";
+import { Map } from "./models/Map.js";
+import { PackedItems } from "./models/PackedItems.js";
+import { PackingList } from "./models/PackingList.js";
+import { RoadTrip } from "./models/RoadTrip.js";
+import { Spotify } from "./models/Spotify.js";
+import { User } from "./models/User.js";
+
+export default async function resetDatabase() {
+    await EmergencyDetails.syncIndexes();
+    await Itinerary.syncIndexes();
+    await Map.syncIndexes();
+    await PackedItems.syncIndexes();
+    await PackingList.syncIndexes();
+    await RoadTrip.syncIndexes();
+    await Spotify.syncIndexes();
+    await User.syncIndexes();
+}
+

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,6 +1,7 @@
-import express from 'express';
-import path from 'path';
-import connectToDatabase from './db/db-connect';
+import express from "express";
+import path from "path";
+import connectToDatabase from "./db/db-connect";
+import resetDatabase from "./db/db-reset";
 
 // Setup Express
 const app = express();
@@ -10,25 +11,29 @@ const port = process.env.PORT || 3001;
 app.use(express.json());
 
 // Setup our routes.
-import routes from './routes';
-app.use('/', routes);
+import routes from "./routes";
+app.use("/", routes);
 
 // Make the "public" folder available statically
-app.use(express.static(path.join(__dirname, '../public')));
+app.use(express.static(path.join(__dirname, "../public")));
 
 // Serve up the frontend's "build" directory, if we're running in production mode.
-if (process.env.NODE_ENV === 'production') {
-    console.log('Running in production!');
+if (process.env.NODE_ENV === "production") {
+    console.log("Running in production!");
 
     // Make all files in that folder public
-    app.use(express.static(path.join(__dirname, '../../frontend/build')));
+    app.use(express.static(path.join(__dirname, "../../frontend/build")));
 
     // If we get any GET request we can't process using one of the server routes, serve up index.html by default.
-    app.get('*', (req, res) => {
-        res.sendFile(path.join(__dirname, '../../frontend/build/index.html'));
+    app.get("*", (req, res) => {
+        res.sendFile(path.join(__dirname, "../../frontend/build/index.html"));
     });
 }
 
 // Start the DB running. Then, once it's connected, start the server.
-connectToDatabase()
-    .then(() => app.listen(port, () => console.log(`App server listening on port ${port}!`)));
+connectToDatabase().then(async () => {
+    await resetDatabase();
+    app.listen(port, () =>
+        console.log(`App server listening on port ${port}!`)
+    );
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,7 +1,7 @@
 import express from "express";
 import path from "path";
 import connectToDatabase from "./db/db-connect";
-import resetDatabase from "./db/db-reset";
+import syncAllIndexes from "./db/db-reset-indexes";
 
 // Setup Express
 const app = express();
@@ -32,7 +32,7 @@ if (process.env.NODE_ENV === "production") {
 
 // Start the DB running. Then, once it's connected, start the server.
 connectToDatabase().then(async () => {
-    await resetDatabase();
+    await syncAllIndexes();
     app.listen(port, () =>
         console.log(`App server listening on port ${port}!`)
     );


### PR DESCRIPTION
Closes #40 

This PR will reset indexes for all models on backend start, which means that we can make changes to the schemas and be allowed to persist objects in the database that follow the new schema.