### PR TITLE
Hook fix

### DIFF
--- a/frontend/src/hooks/useGet.js
+++ b/frontend/src/hooks/useGet.js
@@ -6,7 +6,14 @@ export default function useGet(url, config = {}) {
   const [response, setResponse] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
+
+  const [refetch, setRefetch] = useState(false);
+
   const { getAccessTokenSilently } = useAuth0();
+
+  const handleRefetch = () => {
+    setRefetch(!refetch);
+  };
 
   useEffect(() => {
     async function performGet() {
@@ -29,7 +36,7 @@ export default function useGet(url, config = {}) {
       setLoading(false);
     }
     performGet();
-  }, []);
+  }, [refetch]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return { response, error, loading };
+  return { response, error, loading, refetch: handleRefetch };
 }

--- a/frontend/src/hooks/useGet.js
+++ b/frontend/src/hooks/useGet.js
@@ -36,7 +36,7 @@ export default function useGet(url, config = {}) {
       setLoading(false);
     }
     performGet();
-  }, [refetch]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [refetch]);
 
   return { response, error, loading, refetch: handleRefetch };
 }

--- a/frontend/src/hooks/usePost.js
+++ b/frontend/src/hooks/usePost.js
@@ -1,34 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import axios from 'axios';
 import { useAuth0 } from '@auth0/auth0-react';
 
-export default function usePost(url, body = {}, config = {}) {
-  const [response, setResponse] = useState(null);
-  const [error, setError] = useState(null);
-  const [loading, setLoading] = useState(false);
+export default function usePost() {
   const { getAccessTokenSilently } = useAuth0();
 
-  useEffect(() => {
-    async function performPost() {
-      const accessToken = await getAccessTokenSilently();
-      // set token in Authorization header
-      config.headers = {
-        Authorization: `Bearer ${accessToken}`,
-      };
+  const post = useCallback(async (url, body = {}, config = {}) => {
+    const accessToken = await getAccessTokenSilently();
+    // set token in Authorization header
+    config.headers = {
+      Authorization: `Bearer ${accessToken}`,
+    };
 
-      setLoading(true);
-      try {
-        const axiosResponse = await axios.post(url, body, config);
-        setResponse(axiosResponse);
-        setError(null);
-      } catch (error) {
-        setError(error);
-        setResponse(null);
-      }
-      setLoading(false);
+    try {
+      const axiosResponse = await axios.post(url, body, config);
+      return { response: axiosResponse, error: null };
+    } catch (error) {
+      return { response: null, error };
     }
-    performPost();
-  }, []);
+  });
 
-  return { response, error, loading };
+  return post;
 }

--- a/frontend/src/pages/RoadTripPage/MapPage/MapModal/MapModal.jsx
+++ b/frontend/src/pages/RoadTripPage/MapPage/MapModal/MapModal.jsx
@@ -6,12 +6,11 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import ReactMapGL from 'react-map-gl';
 import Geocoder from 'react-map-gl-geocoder';
-import axios from 'axios';
-import { useAuth0 } from '@auth0/auth0-react';
 import 'react-map-gl-geocoder/dist/mapbox-gl-geocoder.css';
 
-const dotenv = require('dotenv');
+import usePost from '../../../../hooks/usePost';
 
+const dotenv = require('dotenv');
 dotenv.config();
 
 export default function MapModal({ open, handleClose, setDestination, setDestSelected }) {
@@ -31,9 +30,10 @@ export default function MapModal({ open, handleClose, setDestination, setDestSel
   const [destLongitude, setDestLongitude] = useState(170.83285);
 
   const mapAccessToken = process.env.REACT_APP_MAPBOX_TOKEN;
-  const { getAccessTokenSilently } = useAuth0();
   const mapRef = useRef();
   const geocoderContainerRef = useRef();
+
+  const post = usePost();
 
   // Size of map inside the modal - unable to split into separate CSS file
   const mapStyle = {
@@ -67,16 +67,6 @@ export default function MapModal({ open, handleClose, setDestination, setDestSel
   );
 
   async function handleSubmit() {
-    // POST request to set the destination
-    const accessToken = await getAccessTokenSilently();
-
-    // set token in Authorization header
-    const config = {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    };
-
     const destToPost = {
       primaryDestination: {
         long: destLongitude,
@@ -85,9 +75,9 @@ export default function MapModal({ open, handleClose, setDestination, setDestSel
       },
     };
 
-    const destination = await axios.post('/api/roadtrip/6083614ff19eef2de864003d/map', destToPost, config);
+    const { response } = await post('/api/roadtrip/6083614ff19eef2de864003d/map', destToPost);
 
-    setDestination(destination.data);
+    setDestination(response?.data);
 
     // Close the modal
     handleClose();

--- a/frontend/src/pages/RoadTripPage/MapPage/MapModal/MapModal.jsx
+++ b/frontend/src/pages/RoadTripPage/MapPage/MapModal/MapModal.jsx
@@ -11,6 +11,7 @@ import 'react-map-gl-geocoder/dist/mapbox-gl-geocoder.css';
 import usePost from '../../../../hooks/usePost';
 
 const dotenv = require('dotenv');
+
 dotenv.config();
 
 export default function MapModal({ open, handleClose, setDestination, setDestSelected }) {


### PR DESCRIPTION
**Problem**
The `usePost` hook could not be used inside callbacks, which essentially made it useless. There is also no way to refetch data from the `useGet` hook without having the page re-render.

**Solution**
This PR re-writes the usePost wrapper hook so that it can actually be used by components that need to perform a post.

Now, you will call the hook at the top of your component to get the `post` function. Then, you can call `post` and pass in the URL and the body. The logic to apply the authorisation headers is taken care of in the hook.

You can also do error handling by checking if `response` or `error` is undefined.

`MapModal.jsx` shows an example of how to use the hook.

a `refetch` function is also exposed by the `useGet` hook.