### PR TITLE
ignore prettier eol rule in eslint config file

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -20,5 +20,6 @@ module.exports = {
     'no-return-await': 0,
     'implicit-arrow-linebreak': 0,
     'no-new-wrappers': 0,
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },
 };

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -26,5 +26,6 @@ module.exports = {
     'no-underscore-dangle': 0,
     'no-unused-vars': [1, { args: 'all' }],
     'no-shadow': 'off',
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },
 };


### PR DESCRIPTION
I think that this is going mean that eslint stops caring about what line endings you have on a file. Hopefully.