### PR TITLE
Fixes add attendees loading jank

### DIFF
--- a/backend/src/db/controllers/roadtrips.js
+++ b/backend/src/db/controllers/roadtrips.js
@@ -33,10 +33,15 @@ export async function getOrganiser(roadTripId) {
 
 export async function addAttendee(roadTripId, userId) {
   const dbRoadTrip = await getRoadTrip(roadTripId);
-  if (dbRoadTrip.attendees.every((e) => new String(e).valueOf() !== new String(userId).valueOf())) {
+  if (
+    dbRoadTrip.attendees.every((e) => new String(e).valueOf() !== new String(userId).valueOf()) &&
+    new String(dbRoadTrip.organiser).valueOf() != new String(userId).valueOf()
+  ) {
     dbRoadTrip.attendees.push(userId);
     await users.addRoadTripAttending(userId, roadTripId);
+    await dbRoadTrip.save();
+    return dbRoadTrip;
+  } else {
+    return null;
   }
-  await dbRoadTrip.save();
-  return dbRoadTrip;
 }

--- a/backend/src/routes/api/roadtrip/attendees.js
+++ b/backend/src/routes/api/roadtrip/attendees.js
@@ -20,9 +20,13 @@ router.patch('/:id/attendees', async (req, res) => {
   const user = await users.getUserByEmail(req.body.userEmail);
   if (user) {
     const updatedRoadtrip = await roadtrips.addAttendee(roadTripId, user._id);
-    res.json(updatedRoadtrip);
+    if (updatedRoadtrip) {
+      res.json(updatedRoadtrip);
+    } else {
+      res.status(constants.HTTP_BAD_REQUEST).send('This user is already an attendee');
+    }
   } else {
-    res.sendStatus(constants.HTTP_NOT_FOUND);
+    res.status(constants.HTTP_NOT_FOUND).send('User not found');
   }
 });
 

--- a/frontend/src/components/RoadTripTopBar/AttendeesModal/AttendeesModal.jsx
+++ b/frontend/src/components/RoadTripTopBar/AttendeesModal/AttendeesModal.jsx
@@ -24,6 +24,7 @@ export default function AttendeesModal({ open, closeModal }) {
 
   const [email, setEmail] = useState('');
   const [error, setError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
 
   const handleChange = (event) => {
     setEmail(event.target.value);
@@ -39,6 +40,7 @@ export default function AttendeesModal({ open, closeModal }) {
     const { error: addAttendeeError } = await patch(`/api/roadtrip/${id}/attendees`, { userEmail: email });
     if (addAttendeeError) {
       setError(true);
+      setErrorMessage(addAttendeeError.response.data);
     } else {
       refetch();
     }
@@ -49,15 +51,10 @@ export default function AttendeesModal({ open, closeModal }) {
   return (
     <div>
       <Dialog fullWidth open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
-        <ColouredDialogTitle>List of Attendees</ColouredDialogTitle>
+        <ColouredDialogTitle>Attendees</ColouredDialogTitle>
         <CustomDialogContent>
-          {showSpinner && (
-            <div className={styles.spinner}>
-              <Spinner />
-            </div>
-          )}
-          {!showSpinner && (
-            <List>
+          <List>
+            {organiser && (
               <div key={organiser._id}>
                 <ListItem>
                   <ColouredAccountIcon />
@@ -67,16 +64,21 @@ export default function AttendeesModal({ open, closeModal }) {
                   </div>
                 </ListItem>
               </div>
-              {response &&
-                response.data.map((attendee) => (
-                  <div key={attendee._id}>
-                    <ListItem>
-                      <ColouredAccountIcon />
-                      <ColouredListItemText primary={attendee.email} />
-                    </ListItem>
-                  </div>
-                ))}
-            </List>
+            )}
+            {response &&
+              response.data.map((attendee) => (
+                <div key={attendee._id}>
+                  <ListItem>
+                    <ColouredAccountIcon />
+                    <ColouredListItemText primary={attendee.email} />
+                  </ListItem>
+                </div>
+              ))}
+          </List>
+          {showSpinner && (
+            <div className={styles.spinner}>
+              <Spinner />
+            </div>
           )}
         </CustomDialogContent>
         <DialogActions>
@@ -91,7 +93,7 @@ export default function AttendeesModal({ open, closeModal }) {
                 defaultValue={email}
                 onChange={handleChange}
                 error={error}
-                label={error ? 'User not found' : ''}
+                label={error && errorMessage}
                 autoFocus
                 onFocus={(event) => event.target.select()}
               />


### PR DESCRIPTION
**Problem**
When you add a new attendee, currently the list of attendees will get replaced by a spinner, then they will all reappear. It looks a bit funky.

**Changes Made**
Now, the existing list will stay there, a loading spinner will appear, then the new attendee will get added to the bottom of the list

Also, there is better error handling: error for adding the same user to the roadtrip twice:
![image](https://user-images.githubusercontent.com/43567020/117303782-34abbc00-aed1-11eb-8c9d-4a339045e3dd.png)

Closes #83 