### PR TITLE
Improve the spinner shown while being authenticated

### DIFF
--- a/frontend/src/components/Loading/Loading.jsx
+++ b/frontend/src/components/Loading/Loading.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
+import Spinner from '../commons/Spinner/Spinner';
 import styles from './Loading.module.css';
-
-const loadingImg = 'https://cdn.auth0.com/blog/auth0-react-sample/assets/loading.svg';
 
 export default function Loading() {
   return (
     <div className={styles.spinner}>
-      <img src={loadingImg} alt="Loading..." />
+      <Spinner size={200} thickness={1.5} />
     </div>
   );
 }

--- a/frontend/src/components/Loading/Loading.module.css
+++ b/frontend/src/components/Loading/Loading.module.css
@@ -1,12 +1,7 @@
 .spinner {
   position: absolute;
-  display: flex;
-  justify-content: center;
-  height: 100vh;
-  width: 100vw;
-  background-color: white;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  top: 50%;
+  left: 50%;
+  margin-left: -100px;
+  margin-top: -100px;
 }


### PR DESCRIPTION
Instead of it being blue and large, the spinner while authenticating is now the same spinner used elsewhere in the app (expect it is a bit larger).

![image](https://user-images.githubusercontent.com/52437731/117553542-5ad68500-b0a6-11eb-8e37-fe4c44a9edb0.png)

closes #57 
