### PR TITLE
Reset state of modal when it closes

### DIFF
--- a/frontend/src/components/ItineraryWrapper/Itinerary/DailyItinerary/DayCard/AddEventModal/AddEventModal.jsx
+++ b/frontend/src/components/ItineraryWrapper/Itinerary/DailyItinerary/DayCard/AddEventModal/AddEventModal.jsx
@@ -7,15 +7,23 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import TextField from '@material-ui/core/TextField';
 
 export default function AddEventModal({ open, handleClose, addEvent }) {
-  const [description, setDescription] = useState(null);
-  const [location, setLocation] = useState(null);
+  const [description, setDescription] = useState('');
+  const [location, setLocation] = useState('');
   const [time, setTime] = useState('12:30');
   const [notes, setNotes] = useState('');
+
+  const resetState = () => {
+    setDescription('');
+    setLocation('');
+    setNotes('');
+    setTime('12:30');
+  };
 
   const handleSubmit = async () => {
     const event = { description, location, time, notes };
     addEvent(event);
     handleClose();
+    resetState();
   };
 
   return (
@@ -23,11 +31,22 @@ export default function AddEventModal({ open, handleClose, addEvent }) {
       <Dialog fullWidth open={open} onClose={handleClose}>
         <DialogTitle>What would like to do?</DialogTitle>
         <DialogContent>
-          <TextField fullWidth autoFocus label="Description" onChange={(event) => setDescription(event.target.value)} />
-          <TextField fullWidth label="Location" onChange={(event) => setLocation(event.target.value)} />
+          <TextField
+            fullWidth
+            autoFocus
+            defaultValue={description}
+            label="Description"
+            onChange={(event) => setDescription(event.target.value)}
+          />
+          <TextField
+            fullWidth
+            defaultValue={location}
+            label="Location"
+            onChange={(event) => setLocation(event.target.value)}
+          />
           <TextField
             type="time"
-            defaultValue="12:30"
+            defaultValue={time}
             label="Time"
             InputLabelProps={{
               shrink: true,
@@ -37,7 +56,7 @@ export default function AddEventModal({ open, handleClose, addEvent }) {
             }}
             onChange={(event) => setTime(event.target.value)}
           />
-          <TextField defaultValue="" fullWidth label="Notes" onChange={(event) => setNotes(event.target.value)} />
+          <TextField defaultValue={notes} fullWidth label="Notes" onChange={(event) => setNotes(event.target.value)} />
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose} color="primary">


### PR DESCRIPTION
Currently the modal used for adding an event retains the state of a previously submitted event

Changes:

- ResetState method was created to setSet of description, location, time, notes
- This method is called in the handleSubmit method

closes #119 